### PR TITLE
silicon errata issue 3 & 4 workaround

### DIFF
--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -69,7 +69,7 @@ DateTime::DateTime(uint32_t t) {
   t /= 60;
   mm = t % 60;
   t /= 60;
-  hh            = t % 24;
+  hh = t % 24;
   uint16_t days = t / 24;
   uint8_t  leap;
   for (yOff = 0;; ++yOff) {
@@ -437,10 +437,11 @@ void MCP7940_Class::adjust(const DateTime& dt) {
   I2C_write(MCP7940_RTCMIN, int2bcd(dt.minute()));
   I2C_write(MCP7940_RTCHOUR, int2bcd(dt.hour()));
   weekdayWrite(dt.dayOfTheWeek());                        // Update the weekday
-  I2C_write(MCP7940_RTCDATE, int2bcd(dt.day()));          // Write the day of month
   I2C_write(MCP7940_RTCMTH, int2bcd(dt.month()));         // Month, ignore R/O leapyear bit
+  I2C_write(MCP7940_RTCDATE, int2bcd(dt.day()));          // Write the day of month
   I2C_write(MCP7940_RTCYEAR, int2bcd(dt.year() - 2000));  // Write the year
   deviceStart();                                          // Restart the oscillator
+  weekdayWrite(dt.dayOfTheWeek());                        // Silicon errata issue 4
   _SetUnixTime = dt.unixtime();                           // Store time of last change
 }  // of method adjust
 uint8_t MCP7940_Class::weekdayRead() const {


### PR DESCRIPTION
# Description
Microchip has a document with [MCP7940N Family Silicon Errata](https://ww1.microchip.com/downloads/en/DeviceDoc/MCP7940N-Family-Silicon-Errata-80000611D.pdf). It describes 4 hardware issues that the chip has and provides workarounds. This commit aims to implement the workaround for issue 3 and 4. 

From the document:
**3. Issue: Date Value Changing on Month Write**
When writing a different value to the month
register, RTCMTH (0x05), the value of the date
register, RTCDATE (0x04), may change.
Work around:
After writing to the RTCMTH register, verify the
RTCDATE value is correct or write the correct
RTCDATE value again.

**4. Issue: Day of Week Value Changing**
After Write
If the RTCWKDAY register is written while the
oscillator is stopped, it is possible that the value
will read back as a different value after the
oscillator is started.
Work around:
After writing to the RTCWKDAY register, read
the value back after the oscillator is started to
confirm it is correct and, if necessary, rewrite it.

I encountered issue 4 and issue 3 is also relevant for my use case. 

The document suggests for issue 4 to first read back the weekday value and if necessary write it again. I have opted to just write it every time. 

For issue 3 I just switched around the order of writes and then it should be fine.

## Fixes # (issue)
I will write issues for issue 3 & 4 mentioned in the documentation. Issue 1 & 2 should also be checked
#69

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

The problem only occurs in some chips. It seems some batches are more affected then others. This makes reproduction somewhat tricky. For issue 4 what I had to do to reproduce was:
- Stop the oscillator
- Set the day of the week to 4 or 5 
- Start the oscillator
- Read the day of the week
- The day of the week has changed

I have tested the fix for issue 4 on a MCP7940N connected to an ESP32 by writing the weekday with different days and with different dates/times in the registry and then reading it back. I have not tested the fix for issue 3 since I was not able to reproduce the error.

**Test Configuration**:
* Arduino version:
* Arduino Hardware: Esp32-wroom
* SDK: esp-idf
* Development system: Linux

# Checklist:

- [ ] The changes made link back to an existing issue number
- [ ] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [ ] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [ ] My changes generate no new warnings
- [ ] The automated TRAVIS-CI run has a status of "passed"
- [ ] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://zanduino.github.io)
