### PR TITLE
Correct #elif typo

### DIFF
--- a/src/MCP7940.cpp
+++ b/src/MCP7940.cpp
@@ -249,7 +249,7 @@ bool MCP7940_Class::begin(const uint8_t sda, const uint8_t scl, const uint32_t i
   */
 #if defined(ESP8266)
   Wire.begin(sda, scl);  // Start I2C as master device using the specified SDA and SCL
-#elif
+#else
   Wire.begin();  // Start I2C as master device
 #endif
   (void)sda;                // force compiler to ignore this potentially unused parameter


### PR DESCRIPTION
# Description
File MCP7940.cpp has a typo on line 252. It should read `#else`, not `#elif`. This error prevents the library from building.

Fixes #71 
_In order to make tracking easier and to properly document the process,
pull requests should always refer to an active issue in the list - be it a bug fix or an enhancement or some other type of issue._

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Tested with ESP32 (Arduino environment) compiler in PlatformIO.

# Checklist:

- [X] The changes made link back to an existing issue number
- [X] I have performed a self-review of my own code
- [X] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] The code adheres to the [Google Style Guide](https://google.github.io/styleguide/cppguide.html)
- [X] The code follows the existing program documentation style using [doxygen](http://www.doxygen.nl/)
- [ ] I have made corresponding changes to the documentation / Wiki Page(s)
- [X] My changes generate no new warnings
- [ ] The automated TRAVIS-CI run has a status of "passed"
- [ ] I have checked potential areas where regression errors could occur and have found no issues
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[![Zanshin Logo](https://zanduino.github.io/Images/zanshinkanjitiny.gif) <img src="https://zanduino.github.io/Images/zanshintext.gif" width="75"/>](https://zanduino.github.io)
